### PR TITLE
disable React Dev Tools in production

### DIFF
--- a/src/server/templates/pages/main.hbs
+++ b/src/server/templates/pages/main.hbs
@@ -12,6 +12,21 @@
 	</head>
 	<body>
 		<div id="react-root">{{{reactHTML}}}</div>
+		{{#if disableRDT}}
+			{{!-- disable React Dev tools --}}
+			<script type="text/javascript" id="disableReactDevTools">
+				const devTools = window.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+				if(typeof devTools === 'object') {
+					Object.keys(devTools).forEach((key) => {
+						devTools[key] = typeof devTools[key] === 'function'
+							? () => {}
+							: null;
+					});
+				}
+				const node = document.getElementById('disableReactDevTools');
+				node.parentNode.removeChild(node);
+			</script>
+		{{/if}}
 		{{!-- initial Redux state injection --}}
 		<script type="text/javascript" id="preloadedState">
 			{{{preloadedState}}}

--- a/src/server/templates/ssr.jsx
+++ b/src/server/templates/ssr.jsx
@@ -69,6 +69,7 @@ function renderApp(ReactEntry, assets, state = {}) {
 		...getAssets(assets),
 		preloadedState,
 		reactHTML,
+		disableRDT: process.env.NODE_ENV === 'production',
 	});
 }
 
@@ -91,6 +92,7 @@ function renderAppWithRedux(ReactEntry, assets, store) {
 		...getAssets(assets),
 		preloadedState,
 		reactHTML,
+		disableRDT: process.env.NODE_ENV === 'production',
 	});
 }
 


### PR DESCRIPTION
Advanced users can edit stateful component props using RDT, so its proposal for disabling RDT in production builds.